### PR TITLE
 Correct mixing of plain lists and headlines 

### DIFF
--- a/ox-textile.el
+++ b/ox-textile.el
@@ -146,9 +146,13 @@ CONTENTS is the contents of the list.  INFO is a plist holding
 contextual information."
   contents)
 
-(defun org-textile-item-list-depth (item)
-  (let ((parent item)
-	(depth 0))
+(defun org-textile-item-list-depth (item info)
+  (let* ((headline-level
+	  (org-export-get-relative-level
+	   (org-export-get-parent-headline item) info))
+	 (headline-levels (plist-get info :headline-levels))
+	 (parent item)
+	 (depth (max 0 (- headline-level headline-levels))))
     (while (and (setq parent (org-export-get-parent parent))
 		(cl-case (org-element-type parent)
 		  (item t)
@@ -159,10 +163,10 @@ contextual information."
   '((unordered . ?*)
     (ordered . ?#)))
 
-(defun org-textile-list-item-delimiter (item)
+(defun org-textile-list-item-delimiter (item info)
   (let* ((plain-list (org-export-get-parent item))
 	 (type (org-element-property :type plain-list))
-	 (depth (org-textile-item-list-depth item))
+	 (depth (org-textile-item-list-depth item info))
 	 (bullet (cdr (assq type org-textile-list-bullets))))
     (when bullet
      (make-string depth bullet))))
@@ -171,7 +175,7 @@ contextual information."
   "Transcode an ITEM element into Textile format.
 CONTENTS holds the contents of the item.  INFO is a plist holding
 contextual information."
-  (format "%s %s" (org-textile-list-item-delimiter item) contents))
+  (format "%s %s" (org-textile-list-item-delimiter item info) contents))
 
 
 ;;; Example Block

--- a/ox-textile.el
+++ b/ox-textile.el
@@ -148,14 +148,10 @@ contextual information."
 
 (defun org-textile-item-list-depth (item info)
   (let* ((headline (org-export-get-parent-headline item))
-	 (headline-level
-	  (if headline
-	      (org-export-get-relative-level headline info)
-	    0
-	    ))
-	 (headline-levels (plist-get info :headline-levels))
 	 (parent item)
-	 (depth (max 0 (- headline-level headline-levels))))
+	 (depth (or (and headline
+		     (org-export-low-level-p headline info))
+		0 )))
     (while (and (setq parent (org-export-get-parent parent))
 		(cl-case (org-element-type parent)
 		  (item t)

--- a/ox-textile.el
+++ b/ox-textile.el
@@ -147,9 +147,12 @@ contextual information."
   contents)
 
 (defun org-textile-item-list-depth (item info)
-  (let* ((headline-level
-	  (org-export-get-relative-level
-	   (org-export-get-parent-headline item) info))
+  (let* ((headline (org-export-get-parent-headline item))
+	 (headline-level
+	  (if headline
+	      (org-export-get-relative-level headline info)
+	    0
+	    ))
 	 (headline-levels (plist-get info :headline-levels))
 	 (parent item)
 	 (depth (max 0 (- headline-level headline-levels))))

--- a/test-ox-textile.el
+++ b/test-ox-textile.el
@@ -99,6 +99,59 @@ h6. 5th headline
 ** 7th headline
 "))
 
+;;; Mixed headlines and list items
+(ert-deftest test-org-textile/headline-mixed ()
+  (org-textile-test-transcode-body
+   "* 1st headline
+** 2nd headline
+*** 3rd headline
+**** 4th headline
+***** 5th headline
+- 1st list item
+  - 2nd list item"
+"\nh2. 1st headline
+
+
+h3. 2nd headline
+
+
+h4. 3rd headline
+
+
+h5. 4th headline
+
+
+h6. 5th headline
+
+* 1st list item
+** 2nd list item
+"))
+
+;;; Headlines, list items and limited headline level
+(ert-deftest test-org-textile/headline-limited ()
+  (org-textile-test-transcode-body
+   "#+OPTIONS: H:1
+* 1st headline
+- 1st list item
+  - 2nd list item
+** 2nd headline
+*** 3rd headline
+- 3rd list item
+  - 4th list item
+**** 4th headline
+***** 5th headline
+"
+"\nh2. 1st headline
+
+* 1st list item
+** 2nd list item
+* 2nd headline
+** 3rd headline
+*** 3rd list item
+**** 4th list item
+*** 4th headline
+**** 5th headline
+"))
 
 ;;; List
 (ert-deftest test-org-textile/unordered-list ()

--- a/test-ox-textile.el
+++ b/test-ox-textile.el
@@ -107,6 +107,7 @@ h6. 5th headline
 *** 3rd headline
 **** 4th headline
 ***** 5th headline
+****** 6th headline
 - 1st list item
   - 2nd list item"
 "\nh2. 1st headline
@@ -123,8 +124,9 @@ h5. 4th headline
 
 h6. 5th headline
 
-* 1st list item
-** 2nd list item
+* 6th headline
+** 1st list item
+*** 2nd list item
 "))
 
 ;;; Headlines, list items and limited headline level


### PR DESCRIPTION
Retrieve the starting depth of a plain list as the level of the parent
headline. This way, plain lists and headlines can be mixed even if
lower level headlines get exportet as bullet points. (H: option)