### PR TITLE
remove double newlines from plain lists

### DIFF
--- a/ox-textile.el
+++ b/ox-textile.el
@@ -144,7 +144,7 @@ CONTENTS is the headline contents."
   "Transcode a PLAIN-LIST element into Textile format.
 CONTENTS is the contents of the list.  INFO is a plist holding
 contextual information."
-  contents)
+  (replace-regexp-in-string "\n\n" "\n" contents))
 
 (defun org-textile-item-list-depth (item info)
   (let* ((headline (org-export-get-parent-headline item))

--- a/test-ox-textile.el
+++ b/test-ox-textile.el
@@ -179,6 +179,24 @@ h6. 5th headline
 **** list
 ***** list\n"))
 
+;;; Spurious newlines between list items
+(ert-deftest test-org-textile/unordered-list-newlines ()
+  (org-textile-test-transcode-body
+   "
+- list
+
+  - list
+
+    - list
+      - list
+        - list"
+   "* list
+** list
+*** list
+**** list
+***** list\n"))
+
+
 (ert-deftest test-org-textile/ordered-list ()
   (org-textile-test-transcode-body
    "1. list 1


### PR DESCRIPTION
At least redcloth does not support blank lines in plain lists. This change does remove the blank lines.

Let me know whether this should be standard of configurable.