### PR TITLE
fix org-trim usage

### DIFF
--- a/ox-textile.el
+++ b/ox-textile.el
@@ -181,7 +181,7 @@ contextual information."
        (format "%s %s :=%s"
                delim
                (org-export-data (org-element-property :tag item) info)
-               (concat (if (string-match-p "\n" (org-trim contents t)) "\n" " ")
+               (concat (if (string-match-p "\n" (org-trim contents)) "\n" " ")
                        contents)))
       (_
        (format "%s %s" delim contents)))))


### PR DESCRIPTION
- org-trim only takes one string parameter

Org-mode version 8.2.10
GNU Emacs 25.3